### PR TITLE
fix(server): 修复macOS下符号链接入口执行判断

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+import { realpathSync } from "node:fs";
 import { McpServer, ResourceTemplate } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import path from "node:path";
@@ -90,11 +91,22 @@ export async function main(): Promise<void> {
   await server.connect(transport);
 }
 
-const entrypoint = process.argv[1];
-const isDirectExecution =
-  entrypoint != null && import.meta.url === pathToFileURL(path.resolve(entrypoint)).href;
+export function isDirectExecution(
+  entrypoint = process.argv[1],
+  moduleUrl = import.meta.url,
+): boolean {
+  if (entrypoint == null) {
+    return false;
+  }
 
-if (isDirectExecution) {
+  try {
+    return moduleUrl === pathToFileURL(realpathSync(path.resolve(entrypoint))).href;
+  } catch {
+    return false;
+  }
+}
+
+if (isDirectExecution()) {
   main().catch((error: unknown) => {
     const message = error instanceof Error ? error.message : "Unknown error";
     console.error(`Lanhu MCP TypeScript scaffold failed to start: ${message}`);

--- a/tests-ts/server-entrypoint.test.ts
+++ b/tests-ts/server-entrypoint.test.ts
@@ -1,0 +1,32 @@
+import { mkdtempSync, mkdirSync, realpathSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import { describe, expect, it } from "vitest";
+
+import { isDirectExecution } from "../src/server.js";
+
+describe("isDirectExecution", () => {
+  it("treats npm .bin symlinks as direct execution", () => {
+    const tempDir = mkdtempSync(path.join(os.tmpdir(), "lanhu-mcp-"));
+    const realEntry = path.join(tempDir, "node_modules", "mcp-lanhu", "dist", "server.js");
+    const binEntry = path.join(tempDir, "node_modules", ".bin", "mcp-lanhu");
+
+    mkdirSync(path.dirname(realEntry), { recursive: true });
+    mkdirSync(path.dirname(binEntry), { recursive: true });
+    writeFileSync(realEntry, "");
+    symlinkSync("../mcp-lanhu/dist/server.js", binEntry);
+
+    try {
+      expect(isDirectExecution(binEntry, pathToFileURL(realpathSync(realEntry)).href)).toBe(true);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("returns false when the entrypoint does not resolve to the current module", () => {
+    expect(
+      isDirectExecution("/tmp/does-not-match.js", "file:///tmp/another-entry.js"),
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Fix direct-execution detection for the macOS symlink entrypoint used by npm/pnpm `.bin`.

## Problem

When this MCP server is configured in Cursor and launched through the package manager generated `.bin` entry on macOS, Cursor may report that the MCP server has closed unexpectedly.

In practice, the MCP process exits immediately after launch instead of staying connected over stdio.

## Root Cause

The direct-execution check in `src/server.ts` compared:

- `import.meta.url`
- `pathToFileURL(path.resolve(process.argv[1])).href`

On macOS, the npm/pnpm `.bin` entry is typically a symlink to the real built file in `dist/server.js`.

`path.resolve()` normalizes the path, but it does not resolve the symlink target. As a result:

- `process.argv[1]` points to the `.bin` symlink path
- `import.meta.url` points to the real module file

Those two values do not match, so the server incorrectly decides that it is not being executed directly, and `main()` is never called.

## Fix

Resolve the entrypoint to its real filesystem path with `realpathSync()` before converting it to a file URL for comparison.

This makes direct-execution detection work correctly when the package is started from a symlinked `.bin` entry on macOS.

## Validation

- Added a regression test covering the `.bin` symlink entrypoint case
- Verified the full test suite passes